### PR TITLE
Fix event insert error with module six not found

### DIFF
--- a/event-handler/requirements.txt
+++ b/event-handler/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.3.2
 gunicorn==20.1.0
-google-cloud-pubsub==1.1.0
+google-cloud-pubsub==1.7.2
 google-cloud-secret-manager==0.1.0


### PR DESCRIPTION
Pulling in this PR to the main four-keys repo, event-handler fails to parse events without this change.

See: https://github.com/dora-team/fourkeys/pull/469