### PR TITLE
feat(event-handler): Added the event-handler resource name as an outp…

### DIFF
--- a/terraform/modules/fourkeys/outputs.tf
+++ b/terraform/modules/fourkeys/outputs.tf
@@ -2,6 +2,10 @@ output "event_handler_endpoint" {
   value = google_cloud_run_service.event_handler.status[0]["url"]
 }
 
+output "event_handler_name" {
+  value = google_cloud_run_service.event_handler.name
+}
+
 output "event_handler_secret" {
   value     = google_secret_manager_secret_version.event_handler.secret_data
   sensitive = true


### PR DESCRIPTION
Added a new output for the event_handler resource name. 

This can be consumed by domain mapping resources: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_domain_mapping so we can use a custom domain for the event handler service.

