### PR TITLE
fix: updated google-cloud-pubsub to version 2.20.1

### DIFF
--- a/event-handler/requirements.txt
+++ b/event-handler/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.3.2
 gunicorn==20.1.0
-google-cloud-pubsub==1.7.2
+google-cloud-pubsub==2.20.1
 google-cloud-secret-manager==0.1.0


### PR DESCRIPTION
We are still running into the module six missing error in prod, updating to the latest version of the google-cloud-pubsub module resolves this issue. 