### PR TITLE
Update CODEOWNERS for rapid-release-model team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-*       @dinagraves @davidstanke @GoogleCloudPlatform/torus-dpe
+*   @mozilla-services/rapid-release-model


### PR DESCRIPTION
Setting our team as default owners.