### PR TITLE
feat: added ingress annotation and ingress_type variable to allow for…

### DIFF
--- a/terraform/modules/fourkeys/event-handler.tf
+++ b/terraform/modules/fourkeys/event-handler.tf
@@ -3,6 +3,12 @@ resource "google_cloud_run_service" "event_handler" {
   project  = var.project_id
   location = var.region
 
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress" = var.ingress_type
+    }
+  }
+
   template {
     spec {
       containers {

--- a/terraform/modules/fourkeys/variables.tf
+++ b/terraform/modules/fourkeys/variables.tf
@@ -83,3 +83,9 @@ variable "pagerduty_parser_url" {
   description = "The URL for the Pager Duty parser container image. A default value pointing to the project's container registry is defined in under local values of this module."
   default     = ""
 }
+
+variable "ingress_type" {
+  type        = string
+  description = "Set the ingress traffic sources allowed to call the service. Can be set to \"internal-and-cloud-load-balancing\" to use a provisioned application load balancer infront of the event-handler service"
+  default     = "all"
+}


### PR DESCRIPTION
added ingress annotation and ingress_type variable to allow for more restricted access to the event handler service

We will be using an ALB along with Cloud Armor to limit access to the event handler service, the default ingress type of "all" is not restrictive enough for our use case. We can now modify the ingress annotation to allow for ALB access only. 