### PR TITLE
Add environment field to views 🚀 

### DIFF
--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -7,6 +7,10 @@ WITH
         WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.repository.full_name')
       END
         AS metadata_service,
+      CASE
+        WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.deployment_status.environment')
+      END
+        AS metadata_environment,
       id AS deploy_id,
       time_created,
       CASE
@@ -81,6 +85,7 @@ WITH
       deploys.service,
       deploys.metadata_service as deploys_service,
       changes_raw.metadata_service as changes_service,
+      deploys.metadata_environment as environment,
       deploy_id,
       deploys.time_created time_created,
       change_metadata,
@@ -98,6 +103,7 @@ SELECT
   service,
   deploys_service,
   changes_service,
+  environment,
   deploy_id,
   time_created,
   main_commit,
@@ -113,4 +119,5 @@ GROUP BY
   4,
   5,
   6,
-  7;
+  7,
+  8;

--- a/queries/incidents.sql
+++ b/queries/incidents.sql
@@ -4,6 +4,7 @@ SELECT
   metadata_service,
   service_catalog.service,
   incident_id,
+  root.environment as deployment_environment,
   MIN(IF(root.time_created < issue.time_created, root.time_created, issue.time_created)) AS time_created,
   MAX(time_resolved) AS time_resolved,
   ARRAY_AGG(root_cause IGNORE NULLS) AS changes,
@@ -55,7 +56,8 @@ LEFT JOIN (
   SELECT
     time_created,
     changes,
-    service
+    service,
+    environment
   FROM
     four_keys.deployments d,
     d.changes
@@ -66,6 +68,7 @@ GROUP BY
   1,
   2,
   3,
-  4
+  4,
+  5
 HAVING
   MAX(bug) IS TRUE ;


### PR DESCRIPTION
This will enable us to filter deployments for `prod` or `nonprod` environments.