### PR TITLE
Delete pagerduty from changes.sql and deployments.sql

### DIFF
--- a/queries/changes.sql
+++ b/queries/changes.sql
@@ -33,7 +33,6 @@ LEFT JOIN
   `four_keys.services` AS service_catalog
 ON
   CASE
-    WHEN pushes.source = "pagerduty" THEN pushes.metadata_service = service_catalog.pagerduty_service
     WHEN pushes.source = "github" THEN pushes.metadata_service = service_catalog.github_repository
     ELSE FALSE
   END

--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -47,7 +47,6 @@ WITH
       `four_keys.services` AS service_catalog
     ON
       CASE
-        WHEN deploys.source = "pagerduty" THEN deploys.metadata_service = service_catalog.pagerduty_service
         WHEN deploys.source = "github" THEN deploys.metadata_service = service_catalog.github_repository
         ELSE FALSE
       END
@@ -74,7 +73,6 @@ WITH
       `four_keys.services` AS service_catalog
     ON
       CASE
-        WHEN changes_raw.source = "pagerduty" THEN changes_raw.metadata_service = service_catalog.pagerduty_service
         WHEN changes_raw.source = "github" THEN changes_raw.metadata_service = service_catalog.github_repository
         ELSE FALSE
       END


### PR DESCRIPTION
Looks like I accidentally copied `pagerduty` code in the `JOIN` operation when I've added support for our service catalog. 