### PR TITLE
Update incidents view for Google Form responses

### DIFF
--- a/queries/incidents.sql
+++ b/queries/incidents.sql
@@ -1,4 +1,41 @@
 -- Incidents View
+WITH
+  issue AS (
+    SELECT
+      source,
+      CASE
+        WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.repository.full_name')
+        WHEN source LIKE "pagerduty%" THEN JSON_EXTRACT_SCALAR(metadata, '$.event.data.service.summary')
+      END
+        AS metadata_service,
+      CASE
+        WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.issue.number')
+        WHEN source LIKE "pagerduty%" THEN JSON_EXTRACT_SCALAR(metadata, '$.event.data.id')
+      END
+        AS incident_id,
+      CASE
+        WHEN source LIKE "github%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.issue.created_at'))
+        WHEN source LIKE "pagerduty%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.event.occurred_at'))
+      END
+        AS time_created,
+      CASE
+        WHEN source LIKE "github%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.issue.closed_at'))
+        WHEN source LIKE "pagerduty%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.event.occurred_at'))
+      END
+        AS time_resolved,
+      REGEXP_EXTRACT(metadata, r"root cause: ([[:alnum:]]*)") AS root_cause,
+      CASE
+        WHEN source LIKE "github%" THEN REGEXP_CONTAINS(JSON_EXTRACT(metadata, '$.issue.labels'), '"name":"Incident"')
+        WHEN source LIKE "pagerduty%" THEN TRUE # All Pager Duty events are incident-related
+      END
+        AS bug,
+    FROM
+      four_keys.events_raw
+    WHERE
+      event_type LIKE "issue%"
+      OR event_type LIKE "incident%"
+      OR (event_type = "note" AND JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.noteable_type') = 'Issue')
+  )
 SELECT
   source,
   metadata_service,
@@ -8,42 +45,8 @@ SELECT
   MIN(IF(root.time_created < issue.time_created, root.time_created, issue.time_created)) AS time_created,
   MAX(time_resolved) AS time_resolved,
   ARRAY_AGG(root_cause IGNORE NULLS) AS changes,
-FROM (
-  SELECT
-    source,
-    CASE
-      WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.repository.full_name')
-      WHEN source LIKE "pagerduty%" THEN JSON_EXTRACT_SCALAR(metadata, '$.event.data.service.summary')
-    END
-      AS metadata_service,
-    CASE
-      WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.issue.number')
-      WHEN source LIKE "pagerduty%" THEN JSON_EXTRACT_SCALAR(metadata, '$.event.data.id')
-    END
-      AS incident_id,
-    CASE
-      WHEN source LIKE "github%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.issue.created_at'))
-      WHEN source LIKE "pagerduty%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.event.occurred_at'))
-    END
-      AS time_created,
-    CASE
-      WHEN source LIKE "github%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.issue.closed_at'))
-      WHEN source LIKE "pagerduty%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.event.occurred_at'))
-    END
-      AS time_resolved,
-    REGEXP_EXTRACT(metadata, r"root cause: ([[:alnum:]]*)") AS root_cause,
-    CASE
-      WHEN source LIKE "github%" THEN REGEXP_CONTAINS(JSON_EXTRACT(metadata, '$.issue.labels'), '"name":"Incident"')
-      WHEN source LIKE "pagerduty%" THEN TRUE # All Pager Duty events are incident-related
-    END
-      AS bug,
-  FROM
-    four_keys.events_raw
-  WHERE
-    event_type LIKE "issue%"
-    OR event_type LIKE "incident%"
-    OR (event_type = "note" AND JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.noteable_type') = 'Issue')
-) AS issue
+FROM
+  issue
 LEFT JOIN
   `four_keys.services` AS service_catalog
 ON


### PR DESCRIPTION
I created a CTE for the issue subquery in `incidents.sql` to improve comprehensibility. The incident data from the Google Form responses is then merged with incident data from other source such as GitHub and PagerDuty. Lastly, the `JOIN` with `deployments.sql` factors in the deployment environment for which the incident occurred.

See https://mozilla-hub.atlassian.net/browse/RRM-135