### PR TITLE
Use ruff for linting & formatting, add dev environment session

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run: git config blame.ignoreRevsFile .git-blame-ignore-revs
+# to remove the following commits from git-blame
+
+# Run `ruff` formatting after adding to noxfile
+42c3c5d0ff321b8eae521e5fe5aba38f39815271

--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ python3 -m nox -s "{name_of_session}"
 
 The "name_of_session" will be something like "py-3.6(folder='.....').  
 
+## Running linting and formatting
+
+As mentioned above, this project also uses nox to run linting checks. To run just linting checks:
+
+```sh
+python3 -m nox -s "lint"
+```
+
+To fix any (fixable) errors reported by the linting check, there is also a `formatting` session. To automatically apply formatting, run:
+
+```sh
+python3 -m nox -s "formatting"
+```
+
+
 # Data schema
 
 ### `four_keys.events_raw`

--- a/README.md
+++ b/README.md
@@ -199,6 +199,19 @@ To fix any (fixable) errors reported by the linting check, there is also a `form
 python3 -m nox -s "formatting"
 ```
 
+## Setting up virtual environments
+
+To make code changes to a specific service and its tests, it's a good idea to:
+
+- set up a virtual environment
+- install that service's `requirements-test.txt` requirements
+- activate that environment
+
+For the sake of convenience, we have a nox session to set up virtual environments in each service:
+
+```sh
+python3 -m nox -s "dev"
+```
 
 # Data schema
 

--- a/bq-workers/argocd-parser/main.py
+++ b/bq-workers/argocd-parser/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -54,11 +53,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204

--- a/bq-workers/argocd-parser/main_test.py
+++ b/bq-workers/argocd-parser/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture

--- a/bq-workers/circleci-parser/main.py
+++ b/bq-workers/circleci-parser/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -58,11 +57,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204

--- a/bq-workers/circleci-parser/main_test.py
+++ b/bq-workers/circleci-parser/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture

--- a/bq-workers/cloud-build-parser/main.py
+++ b/bq-workers/cloud-build-parser/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -53,11 +52,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204
@@ -74,7 +73,11 @@ def process_cloud_build_event(attr, msg):
     metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
 
     # Most up to date timestamp for the event
-    time_created = (metadata.get("finishTime") or metadata.get("startTime") or metadata.get("createTime"))
+    time_created = (
+        metadata.get("finishTime")
+        or metadata.get("startTime")
+        or metadata.get("createTime")
+    )
 
     build_event = {
         "event_type": event_type,

--- a/bq-workers/cloud-build-parser/main_test.py
+++ b/bq-workers/cloud-build-parser/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture
@@ -58,7 +58,9 @@ def test_missing_msg_attributes(client):
 
 
 def test_cloud_build_event_processed(client):
-    data = json.dumps({"createTime": 1, "startTime": 2, "finishTime": 3}).encode("utf-8")
+    data = json.dumps({"createTime": 1, "startTime": 2, "finishTime": 3}).encode(
+        "utf-8"
+    )
     pubsub_msg = {
         "message": {
             "data": base64.b64encode(data).decode("utf-8"),

--- a/bq-workers/github-parser/main.py
+++ b/bq-workers/github-parser/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -58,11 +57,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204
@@ -76,10 +75,19 @@ def process_github_event(headers, msg):
     if "Mock" in headers:
         source += "mock"
 
-    types = {"push", "pull_request", "pull_request_review",
-             "pull_request_review_comment", "issues",
-             "issue_comment", "check_run", "check_suite", "status",
-             "deployment_status", "release"}
+    types = {
+        "push",
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "issues",
+        "issue_comment",
+        "check_run",
+        "check_suite",
+        "status",
+        "deployment_status",
+        "release",
+    }
 
     if event_type not in types:
         raise Exception("Unsupported GitHub event: '%s'" % event_type)
@@ -111,13 +119,16 @@ def process_github_event(headers, msg):
         e_id = metadata["comment"]["id"]
 
     if event_type == "check_run":
-        time_created = (metadata["check_run"]["completed_at"] or
-                        metadata["check_run"]["started_at"])
+        time_created = (
+            metadata["check_run"]["completed_at"] or metadata["check_run"]["started_at"]
+        )
         e_id = metadata["check_run"]["id"]
 
     if event_type == "check_suite":
-        time_created = (metadata["check_suite"]["updated_at"] or
-                        metadata["check_suite"]["created_at"])
+        time_created = (
+            metadata["check_suite"]["updated_at"]
+            or metadata["check_suite"]["created_at"]
+        )
         e_id = metadata["check_suite"]["id"]
 
     if event_type == "deployment_status":
@@ -129,8 +140,9 @@ def process_github_event(headers, msg):
         e_id = metadata["id"]
 
     if event_type == "release":
-        time_created = (metadata["release"]["published_at"] or
-                        metadata["release"]["created_at"])
+        time_created = (
+            metadata["release"]["published_at"] or metadata["release"]["created_at"]
+        )
         e_id = metadata["release"]["id"]
 
     github_event = {

--- a/bq-workers/github-parser/main_test.py
+++ b/bq-workers/github-parser/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture
@@ -59,9 +59,7 @@ def test_missing_msg_attributes(client):
 
 def test_github_event_processed(client):
     headers = {"X-Github-Event": "push", "X-Hub-Signature": "foo"}
-    commit = json.dumps({"head_commit": {"timestamp": 0, "id": "bar"}}).encode(
-        "utf-8"
-    )
+    commit = json.dumps({"head_commit": {"timestamp": 0, "id": "bar"}}).encode("utf-8")
     pubsub_msg = {
         "message": {
             "data": base64.b64encode(commit).decode("utf-8"),
@@ -93,17 +91,14 @@ def test_github_event_processed(client):
 
 
 def test_github_event_avoid_id_conflicts_pull_requests(client):
-
     headers = {"X-Github-Event": "pull_request", "X-Hub-Signature": "foo"}
-    commit = json.dumps({
-        "pull_request": {
-            "updated_at": "2021-06-15T13:12:14Z"
-        },
-        "repository": {
-            "name": "reponame"
-        },
-        "number": 477
-    }).encode("utf-8")
+    commit = json.dumps(
+        {
+            "pull_request": {"updated_at": "2021-06-15T13:12:14Z"},
+            "repository": {"name": "reponame"},
+            "number": 477,
+        }
+    ).encode("utf-8")
 
     encoded_commit = {
         "data": base64.b64encode(commit).decode("utf-8"),
@@ -111,26 +106,22 @@ def test_github_event_avoid_id_conflicts_pull_requests(client):
         "message_id": "foobar",
     }
 
-    github_event_calculated = main.process_github_event(headers=headers, msg=encoded_commit)
-    github_event_expected = {
-        "id": "reponame/477"
-    }
+    github_event_calculated = main.process_github_event(
+        headers=headers, msg=encoded_commit
+    )
+    github_event_expected = {"id": "reponame/477"}
 
     assert github_event_calculated["id"] == github_event_expected["id"]
 
 
 def test_github_event_avoid_id_conflicts_issues(client):
-
     headers = {"X-Github-Event": "issues", "X-Hub-Signature": "foo"}
-    commit = json.dumps({
-        "issue": {
-            "updated_at": "2021-06-15T13:12:14Z",
-            "number": 477
-        },
-        "repository": {
-            "name": "reponame"
+    commit = json.dumps(
+        {
+            "issue": {"updated_at": "2021-06-15T13:12:14Z", "number": 477},
+            "repository": {"name": "reponame"},
         }
-    }).encode("utf-8")
+    ).encode("utf-8")
 
     encoded_commit = {
         "data": base64.b64encode(commit).decode("utf-8"),
@@ -138,9 +129,9 @@ def test_github_event_avoid_id_conflicts_issues(client):
         "message_id": "foobar",
     }
 
-    github_event_calculated = main.process_github_event(headers=headers, msg=encoded_commit)
-    github_event_expected = {
-        "id": "reponame/477"
-    }
+    github_event_calculated = main.process_github_event(
+        headers=headers, msg=encoded_commit
+    )
+    github_event_expected = {"id": "reponame/477"}
 
     assert github_event_calculated["id"] == github_event_expected["id"]

--- a/bq-workers/gitlab-parser/main.py
+++ b/bq-workers/gitlab-parser/main.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import base64
-from datetime import datetime
-import os
 import json
+import os
+from datetime import datetime
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -59,11 +58,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204
@@ -77,10 +76,17 @@ def process_gitlab_event(headers, msg):
     if "Mock" in headers:
         source += "mock"
 
-    types = {"push", "merge_request",
-             "note", "tag_push", "issue",
-             "pipeline", "job", "deployment",
-             "build"}
+    types = {
+        "push",
+        "merge_request",
+        "note",
+        "tag_push",
+        "issue",
+        "pipeline",
+        "job",
+        "deployment",
+        "build",
+    }
 
     metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
 
@@ -99,15 +105,14 @@ def process_gitlab_event(headers, msg):
         event_object = metadata["object_attributes"]
         e_id = event_object["id"]
         time_created = (
-            event_object.get("updated_at") or
-            event_object.get("finished_at") or
-            event_object.get("created_at"))
+            event_object.get("updated_at")
+            or event_object.get("finished_at")
+            or event_object.get("created_at")
+        )
 
     if event_type in ("job"):
         e_id = metadata["build_id"]
-        time_created = (
-            event_object.get("finished_at") or
-            event_object.get("started_at"))
+        time_created = event_object.get("finished_at") or event_object.get("started_at")
 
     if event_type in ("deployment"):
         e_id = metadata["deployment_id"]
@@ -116,16 +121,17 @@ def process_gitlab_event(headers, msg):
     if event_type in ("build"):
         e_id = metadata["build_id"]
         time_created = (
-            metadata.get("build_finished_at") or
-            metadata.get("build_started_at") or
-            metadata.get("build_created_at"))
+            metadata.get("build_finished_at")
+            or metadata.get("build_started_at")
+            or metadata.get("build_created_at")
+        )
 
     # Some timestamps come in a format like "2021-04-28 21:50:00 +0200"
     # BigQuery does not accept this as a valid format
     # Removing the extra timezone information below
     try:
-        dt = datetime.strptime(time_created, '%Y-%m-%d %H:%M:%S %z')
-        time_created = dt.strftime('%Y-%m-%d %H:%M:%S')
+        dt = datetime.strptime(time_created, "%Y-%m-%d %H:%M:%S %z")
+        time_created = dt.strftime("%Y-%m-%d %H:%M:%S")
 
     # If the timestamp is not parsed correctly,
     # we will default to the string from the event payload

--- a/bq-workers/gitlab-parser/main_test.py
+++ b/bq-workers/gitlab-parser/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture
@@ -59,10 +59,13 @@ def test_missing_msg_attributes(client):
 
 def test_gitlab_event_processed(client):
     headers = {"X-Gitlab-Event": "push", "X-Gitlab-Token": "foo"}
-    data = json.dumps({"object_kind": "push",
-                       "checkout_sha": "foo",
-                       "commits": [{"id": "foo", "timestamp": 2}],
-                       }).encode("utf-8")
+    data = json.dumps(
+        {
+            "object_kind": "push",
+            "checkout_sha": "foo",
+            "commits": [{"id": "foo", "timestamp": 2}],
+        }
+    ).encode("utf-8")
 
     pubsub_msg = {
         "message": {
@@ -97,11 +100,14 @@ def test_gitlab_event_processed(client):
 
 def test_timestamp_timezone_event_processed(client):
     headers = {"X-Gitlab-Event": "deployment", "X-Gitlab-Token": "foo"}
-    data = json.dumps({"object_kind": "deployment",
-                       "short_sha": "279484c0",
-                       "status_changed_at": "2021-04-28 21:50:00 +0200",
-                       "deployment_id": 15,
-                       }).encode("utf-8")
+    data = json.dumps(
+        {
+            "object_kind": "deployment",
+            "short_sha": "279484c0",
+            "status_changed_at": "2021-04-28 21:50:00 +0200",
+            "deployment_id": 15,
+        }
+    ).encode("utf-8")
 
     pubsub_msg = {
         "message": {

--- a/bq-workers/new-source-template/main.py
+++ b/bq-workers/new-source-template/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -52,11 +51,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204

--- a/bq-workers/new-source-template/main_test.py
+++ b/bq-workers/new-source-template/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture

--- a/bq-workers/pagerduty-parser/main.py
+++ b/bq-workers/pagerduty-parser/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -52,11 +51,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(f"EXCEPTION raised  {json.dumps(entry)}")
     return "", 204
 
@@ -68,7 +67,7 @@ def process_pagerduty_event(msg):
 
     # Unique hash for the event
     signature = shared.create_unique_id(msg)
-    event = metadata['event']
+    event = metadata["event"]
     event_type = event["event_type"]
     types = {"incident.triggered", "incident.resolved"}
     if event_type not in types:
@@ -76,13 +75,15 @@ def process_pagerduty_event(msg):
 
     pagerduty_event = {
         "event_type": event_type,  # Event type, eg "incident.trigger", "incident.resolved", etc
-        "id": event['id'],  # Event ID,
+        "id": event["id"],  # Event ID,
         "metadata": json.dumps(metadata),  # The body of the msg
         "signature": signature,  # The unique event signature
         "msg_id": msg["message_id"],  # The pubsub message id
-        "time_created" : event['occurred_at'],  # The timestamp of with the event resolved
+        "time_created": event[
+            "occurred_at"
+        ],  # The timestamp of with the event resolved
         "source": "pagerduty",  # The name of the source, eg "pagerduty"
-        }
+    }
 
     print(f"Pager Duty event to metrics--------> {pagerduty_event}")
     return pagerduty_event

--- a/bq-workers/pagerduty-parser/main_test.py
+++ b/bq-workers/pagerduty-parser/main_test.py
@@ -14,12 +14,12 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture
@@ -58,7 +58,16 @@ def test_missing_msg_attributes(client):
 
 
 def test_pagerduty_event_processed(client):
-    data = json.dumps({"foo": "bar", "event": {"id": "foo", "occurred_at": 0, "event_type": "incident.triggered"}}).encode("utf-8")
+    data = json.dumps(
+        {
+            "foo": "bar",
+            "event": {
+                "id": "foo",
+                "occurred_at": 0,
+                "event_type": "incident.triggered",
+            },
+        }
+    ).encode("utf-8")
     pubsub_msg = {
         "message": {
             "data": base64.b64encode(data).decode("utf-8"),

--- a/bq-workers/tekton-parser/main.py
+++ b/bq-workers/tekton-parser/main.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import base64
-import os
 import json
+import os
 
 import shared
-
 from cloudevents.http import from_http, to_json
 from flask import Flask, request
 
@@ -55,11 +54,11 @@ def index():
 
     except Exception as e:
         entry = {
-                "severity": "WARNING",
-                "msg": "Data not saved to BigQuery",
-                "errors": str(e),
-                "json_payload": envelope
-            }
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope,
+        }
         print(json.dumps(entry))
 
     return "", 204

--- a/bq-workers/tekton-parser/main_test.py
+++ b/bq-workers/tekton-parser/main_test.py
@@ -14,14 +14,13 @@
 
 import base64
 import json
+from unittest import mock
 
-import main
+import pytest
 import shared
-
 from cloudevents.http import CloudEvent, to_structured
 
-from unittest import mock
-import pytest
+import main
 
 
 @pytest.fixture
@@ -64,7 +63,7 @@ def test_tekton_source_event_processed(client):
         "type": "tekton.foo",
         "source": "https://example.com/event-producer",
         "time": 0,
-        "id": "bar"
+        "id": "bar",
     }
     data = {"pipelineRun": {"metadata": {"uid": "foo"}}}
     event = CloudEvent(attributes, data)

--- a/data-generator/util_compare_dicts.py
+++ b/data-generator/util_compare_dicts.py
@@ -2,7 +2,6 @@ def flatten(d, sep="_"):
     obj = {}
 
     def recurse(t, parent_key=""):
-
         if isinstance(t, list):
             for i in range(len(t)):
                 recurse(t[i], parent_key + sep + str(i) if parent_key else str(i))
@@ -18,7 +17,6 @@ def flatten(d, sep="_"):
 
 
 def compare_dicts(dict_a, dict_b):
-
     errors = []
 
     # flatten any nested structures, so we only need one pass
@@ -29,7 +27,6 @@ def compare_dicts(dict_a, dict_b):
         errors.append("dictionary keys do not match")
 
     for key in flat_dict_a:
-
         if not isinstance(flat_dict_a[key], type(flat_dict_b[key])):
             errors.append(
                 f"type mismatch comparing '{key}': {type(flat_dict_a[key]).__name__} != {type(flat_dict_b[key]).__name__}"

--- a/data-generator/util_compare_dicts_test.py
+++ b/data-generator/util_compare_dicts_test.py
@@ -2,20 +2,39 @@ import util_compare_dicts
 
 
 def test_flatten():
-    assert util_compare_dicts.flatten({"x": 2, "y": {"z": 3}}) == {
-        "x": 2, "y_z": 3}
+    assert util_compare_dicts.flatten({"x": 2, "y": {"z": 3}}) == {"x": 2, "y_z": 3}
     assert util_compare_dicts.flatten({"x": 2, "y": 3}) == {"x": 2, "y": 3}
 
 
 def test_compare():
-    assert util_compare_dicts.compare_dicts(
-        {"x": "bar", "y": "baz"}, {"x": "bar", "y": "baz"}) == "pass"
-    assert util_compare_dicts.compare_dicts(
-        {"x": "bar", "y": {"z": "baz"}}, {"x": "bar", "y": {"z": "baz"}}) == "pass"
+    assert (
+        util_compare_dicts.compare_dicts(
+            {"x": "bar", "y": "baz"}, {"x": "bar", "y": "baz"}
+        )
+        == "pass"
+    )
+    assert (
+        util_compare_dicts.compare_dicts(
+            {"x": "bar", "y": {"z": "baz"}}, {"x": "bar", "y": {"z": "baz"}}
+        )
+        == "pass"
+    )
 
-    assert util_compare_dicts.compare_dicts(
-            {"x": "bar", "y": "baz"}, {"x": "bar", "y": "wrong"}) != "pass"
-    assert util_compare_dicts.compare_dicts(
-        {"x": "bar", "y": "baz"}, {"x": "bar", "y": 42}) != "pass"
-    assert util_compare_dicts.compare_dicts(
-        {"x": "bar", "y": {"z": "baz"}}, {"x": "bar", "y": {"z": "wrong"}}) != "pass"
+    assert (
+        util_compare_dicts.compare_dicts(
+            {"x": "bar", "y": "baz"}, {"x": "bar", "y": "wrong"}
+        )
+        != "pass"
+    )
+    assert (
+        util_compare_dicts.compare_dicts(
+            {"x": "bar", "y": "baz"}, {"x": "bar", "y": 42}
+        )
+        != "pass"
+    )
+    assert (
+        util_compare_dicts.compare_dicts(
+            {"x": "bar", "y": {"z": "baz"}}, {"x": "bar", "y": {"z": "wrong"}}
+        )
+        != "pass"
+    )

--- a/event-handler/event_handler.py
+++ b/event-handler/event_handler.py
@@ -16,7 +16,7 @@ import json
 import os
 import sys
 
-from flask import abort, Flask, request
+from flask import Flask, abort, request
 from google.cloud import pubsub_v1
 
 import sources
@@ -76,9 +76,7 @@ def publish_to_pubsub(source, msg, headers):
         print(topic_path)
 
         # Pub/Sub data must be bytestring, attributes must be strings
-        future = publisher.publish(
-            topic_path, data=msg, headers=json.dumps(headers)
-        )
+        future = publisher.publish(topic_path, data=msg, headers=json.dumps(headers))
 
         exception = future.exception()
         if exception:

--- a/event-handler/sources.py
+++ b/event-handler/sources.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import hmac
-from hashlib import sha1, sha256
 import os
+from hashlib import sha1, sha256
 
 from google.cloud import secretmanager
 
@@ -60,7 +60,7 @@ def circleci_verification(signature, body):
         # Get secret from Cloud Secret Manager
         secret = get_secret(PROJECT_NAME, "event-handler", "latest")
         # Compute the hashed signature
-        hashed = hmac.new(secret, body, 'sha256')
+        hashed = hmac.new(secret, body, "sha256")
         expected_signature += hashed.hexdigest()
 
     except Exception as e:
@@ -117,9 +117,7 @@ def get_secret(project_name, secret_name, version_num):
     """
     try:
         client = secretmanager.SecretManagerServiceClient()
-        name = client.secret_version_path(
-            project_name, secret_name, version_num
-        )
+        name = client.secret_version_path(project_name, secret_name, version_num)
         secret = client.access_secret_version(name)
         return secret.payload.data
     except Exception as e:
@@ -149,19 +147,9 @@ def get_source(headers):
 
 
 AUTHORIZED_SOURCES = {
-    "github": EventSource(
-        "X-Hub-Signature", github_verification
-        ),
-    "gitlab": EventSource(
-        "X-Gitlab-Token", simple_token_verification
-        ),
-    "tekton": EventSource(
-        "tekton-secret", simple_token_verification
-        ),
-    "circleci": EventSource(
-        "Circleci-Signature", circleci_verification
-        ),
-    "pagerduty": EventSource(
-        "X-Pagerduty-Signature", pagerduty_verification
-        ),
+    "github": EventSource("X-Hub-Signature", github_verification),
+    "gitlab": EventSource("X-Gitlab-Token", simple_token_verification),
+    "tekton": EventSource("tekton-secret", simple_token_verification),
+    "circleci": EventSource("Circleci-Signature", circleci_verification),
+    "pagerduty": EventSource("X-Pagerduty-Signature", pagerduty_verification),
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import nox
 
+import nox
 
 #
 # Utility Functions
@@ -84,44 +84,18 @@ def test(session, folder):
 #
 
 
-# Ignore I202 "Additional newline in a section of imports." to accommodate
-# region tags in import blocks. Since we specify an explicit ignore, we also
-# have to explicitly ignore the list of default ignores:
-# `E121,E123,E126,E226,E24,E704,W503,W504` as shown by `flake8 --help`.
-def _determine_local_import_names(start_dir):
-    """Determines all import names that should be considered "local".
-    This is used when running the linter to insure that import order is
-    properly checked.
-    """
-    file_ext_pairs = [os.path.splitext(path) for path in os.listdir(start_dir)]
-    return [
-        basename
-        for basename, extension in file_ext_pairs
-        if extension == ".py"
-        or os.path.isdir(os.path.join(start_dir, basename))
-        and basename not in ("__pycache__")
-    ]
-
-
-FLAKE8_COMMON_ARGS = [
-    "--show-source",
-    "--builtin=gettext",
-    "--max-complexity=20",
-    "--import-order-style=google",
-    "--exclude=.nox,.cache,env,lib,generated_pb2,*_pb2.py,*_pb2_grpc.py",
-    "--ignore=E121,E123,E126,E203,E226,E24,E266,E501,E704,W503,W504,I100,I201,I202",
-    "--max-line-length=88",
-]
+@nox.session
+def lint(session):
+    session.install("ruff")
+    session.run("ruff", "format", "--check", ".")
+    session.run("ruff", "check", ".")
 
 
 @nox.session
-def lint(session):
-    session.install("flake8", "flake8-import-order")
+def formatting(session):
+    session.install("ruff")
+    session.run("ruff", "format", ".")
+    session.run("ruff", "check", ".", "--fix")
 
-    local_names = _determine_local_import_names(".")
-    args = FLAKE8_COMMON_ARGS + [
-        "--application-import-names",
-        ",".join(local_names),
-        ".",
-    ]
-    session.run("flake8", *args)
+
+nox.options.sessions = ["lint", "test"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pathlib
 
 import nox
 
@@ -95,6 +96,22 @@ def formatting(session):
     session.install("ruff")
     session.run("ruff", "format", ".")
     session.run("ruff", "check", ".", "--fix")
+
+
+@nox.session(python=False)
+@nox.parametrize("folder", FOLDERS)
+def dev(session: nox.Session, folder) -> None:
+    """Create Python virtual environments in subdirectories containing tests"""
+
+    session.chdir(folder)
+
+    VENV_DIR = pathlib.Path("./.venv").resolve()
+    session.run("python", "-m", "venv", os.fsdecode(VENV_DIR), silent=True)
+
+    python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
+    session.run(
+        python, "-m", "pip", "install", "-r", "requirements-test.txt", external=True
+    )
 
 
 nox.options.sessions = ["lint", "test"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,7 @@ import nox
 # Utility Functions
 #
 
+
 def _collect_dirs(
     start_dir,
     suffix="_test.py",
@@ -41,9 +42,7 @@ def _collect_dirs(
             yield parent
         else:
             # Filter out dirs we don't want to recurse into
-            subdirs[:] = [
-                s for s in subdirs if s[0].isalpha()
-            ]
+            subdirs[:] = [s for s in subdirs if s[0].isalpha()]
 
 
 #
@@ -67,7 +66,7 @@ def _session_tests(session, folder):
         # Pytest will return 5 when no tests are collected. This can happen
         # on travis where slow and flaky tests are excluded.
         # See http://doc.pytest.org/en/latest/_modules/_pytest/main.html
-        success_codes=[0, 5]
+        success_codes=[0, 5],
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,7 +73,7 @@ def _session_tests(session, folder):
 
 @nox.session(python=["3.12"])
 @nox.parametrize("folder", FOLDERS)
-def py(session, folder):
+def test(session, folder):
     """Runs py.test for a folder using the specified version of Python."""
     session.install("-r", "requirements-test.txt")
     _session_tests(session, folder)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+# https://docs.astral.sh/ruff/settings/#src
+src = [".", "data-generator", "event-handler", "bq-workers/*", "shared"]
+
+[tool.ruff.lint]
+# Enables pyflakes, subset of pycodestyle, and isort rules
+# Adapted from Ruff's default configuration https://docs.astral.sh/ruff/configuration/#__tabbed_1_1
+# https://docs.astral.sh/ruff/rules/#pyflakes-f
+# https://docs.astral.sh/ruff/rules/#error-e
+# https://docs.astral.sh/ruff/rules/#isort-i
+extend-select = ["E4", "E7", "E9", "F", "I"]
+
+[tool.ruff.lint.isort]
+# Though this is a package we specify in `src`, since we pip-install it from
+# the git repository like git+https://github.com/mozilla-services/fourkeys.git#egg=shared&subdirectory=shared
+# it should be treated as a third party
+known-third-party = ["shared"]

--- a/shared/setup.py
+++ b/shared/setup.py
@@ -15,13 +15,13 @@
 from setuptools import setup
 
 setup(
-   name='shared',
-   version='1.0',
-   description='Shared functions for the Four Keys pipeline',
-   url='git@github.com:four-keys-playground.git#egg=shared&subdirectory=shared',
-   author='Google Inc.',
-   license='Apache-2.0',
-   py_modules=['shared'],
-   install_requires=['google-cloud-bigquery'],
-   zip_safe=False
+    name="shared",
+    version="1.0",
+    description="Shared functions for the Four Keys pipeline",
+    url="git@github.com:four-keys-playground.git#egg=shared&subdirectory=shared",
+    author="Google Inc.",
+    license="Apache-2.0",
+    py_modules=["shared"],
+    install_requires=["google-cloud-bigquery"],
+    zip_safe=False,
 )

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -69,12 +69,7 @@ def insert_row_into_events_enriched(event):
         table = client.get_table(table_ref)
 
         # Insert row
-        row_to_insert = [
-            (
-                event["events_raw_signature"],
-                event["enriched_metadata"]
-            )
-        ]
+        row_to_insert = [(event["events_raw_signature"], event["enriched_metadata"])]
         bq_errors = client.insert_rows(table, row_to_insert)
 
         # If errors, log to Stackdriver


### PR DESCRIPTION
This PR:
- replaces `flake8` with `ruff` for linting
- adds a `format` nox session to automate code formatting (and runs that formatting rule)
- adds a `dev` nox session to set up virtual environments in each microservice
  - this combined with this [Python Envy](https://marketplace.visualstudio.com/items?itemName=teticio.python-envy) VSCode extension made my development environment a bit better
  - but, perhaps this project warrants a dedicated monorepo build tool like [pants](https://www.pantsbuild.org/) 🤔 