### PR TITLE
Filter Github messages from repos with app installed

### DIFF
--- a/bq-workers/github-parser/.gitignore
+++ b/bq-workers/github-parser/.gitignore
@@ -1,0 +1,2 @@
+data/*
+!data/app-installations.txt.example

--- a/bq-workers/github-parser/Dockerfile
+++ b/bq-workers/github-parser/Dockerfile
@@ -30,10 +30,10 @@ RUN pip install -r requirements.txt
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
+COPY main.py wsgi.py ./
 
 # Run the web service on container startup.
 # Use gunicorn webserver with one worker process and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 wsgi:app

--- a/bq-workers/github-parser/data/app-installations.txt.example
+++ b/bq-workers/github-parser/data/app-installations.txt.example
@@ -1,0 +1,3 @@
+org/repo
+another-org/another-repo
+another-org/yet-another-repo

--- a/bq-workers/github-parser/wsgi.py
+++ b/bq-workers/github-parser/wsgi.py
@@ -1,0 +1,3 @@
+from main import create_app
+
+app = create_app()

--- a/data-generator/generate_data.py
+++ b/data-generator/generate_data.py
@@ -212,7 +212,7 @@ def make_github_issue(root_cause):
             "labels": [{"name": "Incident"}],
             "body": "root cause: %s" % root_cause["id"],
         },
-        "repository": {"name": "foobar"},
+        "repository": {"name": "foobar", "full_name": "some-org/foobar"},
     }
     return event
 

--- a/data-generator/generate_data_test.py
+++ b/data-generator/generate_data_test.py
@@ -140,7 +140,7 @@ def valid_issue(vcs):
                 "labels": [{"name": "Incident"}],
                 "body": "root cause: 2b04b6d3939608f19776193697e0e30c04d9c6b8",
             },
-            "repository": {"name": "foobar"},
+            "repository": {"name": "foobar", "full_name": "some-org/foobar"},
         }
     elif vcs == "gitlab":
         return {


### PR DESCRIPTION
Ref: https://mozilla-hub.atlassian.net/browse/RRM-172

Don't send repository webhook messages to Bigquery where we also have the app installed, since the message will be a duplicate.

This implementation expects a file to be available at a path stored in an environment variable `APP_INSTALLATIONS_CONFIG_PATH` which contains a full repository name `<org>/<repo>` on each line.