### PR TITLE
Tweak dependabot config to bump dependencies in all dirs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,7 @@ updates:
       interval: "weekly"
   - package-ecosystem: "pip"
     directories:
-      - "/"
-      - "/data-generator"
-      - "/event-handler"
-      - "/bq-workers/*"
+      - "**/*"
     schedule:
       interval: "weekly"
     reviewers:
@@ -18,7 +15,4 @@ updates:
     schedule:
       interval: "weekly"
     directories:
-    - "/bq-workers/*"
-    - "/dashboard"
-    - "/event-handler"
-    - "/setup/fourkeys-builder"
+    - "**/*"


### PR DESCRIPTION
With the previous config, we'd get several PRs for the same dependency bump. For example, for Python, two PRs ([1](https://github.com/mozilla-services/fourkeys/pull/81), [2](https://github.com/mozilla-services/fourkeys/pull/91)) were created for a dependency bump in the event-handler's `requirements.txt` file.

The intent for this new config is to bump each dependency in each service with one PR. We can do this because no service requires a specific version of dependency that's different from another service. The main motivation for this PR was the `pip` package ecosystem, but the same applies for Docker the package ecosystem.