### PR TITLE
Group by deploy_id in incidents view

### DIFF
--- a/queries/incidents.sql
+++ b/queries/incidents.sql
@@ -61,6 +61,7 @@ SELECT
   service_catalog.service,
   incident_id,
   root.environment as deployment_environment,
+  root.deploy_id,
   MIN(IF(root.time_created < issue.time_created, root.time_created, issue.time_created)) AS time_created,
   MAX(time_resolved) AS time_resolved,
   ARRAY_AGG(root_cause IGNORE NULLS) AS changes,
@@ -80,7 +81,8 @@ LEFT JOIN (
     time_created,
     changes,
     service,
-    environment
+    environment,
+    deploy_id
   FROM
     `four_keys.deployments` AS d,
     d.changes
@@ -99,6 +101,7 @@ GROUP BY
   2,
   3,
   4,
-  5
+  5,
+  6
 HAVING
   MAX(bug) IS TRUE ;


### PR DESCRIPTION
This is so that we keep the link between a commit linked to an incident and the deployment it shipped in intact.

We need this in downstream views for accurately measuring Change Failure Rate.