### PR TITLE
Fix failing deployment workflow due to google auth config

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           token_format: 'access_token'
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - uses: docker/login-action@v3
         name: Docker login
@@ -65,7 +65,7 @@ jobs:
         with:
           token_format: 'access_token'
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - uses: docker/login-action@v3
         name: Docker login

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -18,6 +18,9 @@ jobs:
     strategy:
       matrix:
         context: [argocd, circleci, github, pagerduty]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
e.g.: https://github.com/mozilla-services/fourkeys/actions/runs/10882192324/job/30192698107

- add token permissions that were missing in the `build_parser_images` job
- use the correct value for `workload_identity_provider`. We store this value under a new name as a variable, rather than a secret