### PR TITLE
Reduce unneeded gh metadata

### DIFF
--- a/bq-workers/github-parser/main.py
+++ b/bq-workers/github-parser/main.py
@@ -98,6 +98,21 @@ def process_github_event(headers, msg):
         time_created = metadata["head_commit"]["timestamp"]
         e_id = metadata["head_commit"]["id"]
 
+        # remove unused metadata fields to reduce data usage and complexity
+        metadata = {
+            "ref": metadata["ref"],
+            "before": metadata["before"],
+            "after": metadata["after"],
+            "repository": {
+                "full_name": metadata["repository"]["full_name"],
+                "url": metadata["repository"]["url"],
+                "private": metadata["repository"]["private"],
+            },
+            "pusher": metadata["pusher"],
+            "commits": metadata["commits"],
+            "head_commit": metadata["head_commit"],
+        }
+
     if event_type == "pull_request":
         time_created = metadata["pull_request"]["updated_at"]
         e_id = metadata["repository"]["name"] + "/" + str(metadata["number"])
@@ -134,6 +149,24 @@ def process_github_event(headers, msg):
     if event_type == "deployment_status":
         time_created = metadata["deployment_status"]["updated_at"]
         e_id = metadata["deployment_status"]["id"]
+
+        # remove unused metadata fields to reduce data usage and complexity
+        metadata = {
+            "deployment_status": {
+                "state": metadata["deployment_status"]["state"],
+                "environment": metadata["deployment_status"]["environment"], # not sure this is needed, can we just get environment from deployment?
+            },
+            "deployment": {
+                "environment": metadata["deployment"]["environment"],
+                "ref": metadata["deployment"]["ref"],
+                "sha": metadata["deployment"]["sha"],
+            },
+            "repository": {
+                "full_name": metadata["repository"]["full_name"],
+                "url": metadata["repository"]["url"],
+                "private": metadata["repository"]["private"],
+            },
+        }
 
     if event_type == "status":
         time_created = metadata["updated_at"]


### PR DESCRIPTION
### Background
Four Keys queries in [BigQuery](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1smoz-fx-sw-delivery-perf-prod!2sfour_keys) and statistics on the [Grafana dashboard](https://earthangel-b40313e5.influxcloud.net/d/fourkeys/four-keys?orgId=1) take a long time time to run despite being uncomplicated. This is an attempt to reorganize the data sent to BigQuery in order to speed up performance.

### Implementation Details
Reduction of the metadata inserted into tables in BQ from gh push and deployment-status actions. There are very few fields actually utilized in further reporting and cutting it down to these bare necessities can reduce the storage space required of the json metadata to ~25% it's original size (10.6MB -> 2.48MB).

### Testing criteria
This is hard to test in a database environment until deployed, however nox unit testing can be performed on the code itself.

- [x] Nox test performed and succeeded

### Jira Ticket
TBD